### PR TITLE
Add login and signup tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # a-board-view
 
 A React front-end for the [a-board](https://github.com/kakao-bart-lee/a-board) back-end.
-It allows users to sign up, log in, view posts, write new posts and add comments
-through social login links provided by the back-end service.
+It implements the authentication flow described in that project's README: users
+are created via `POST /users` and receive a JWT from `POST /auth/token`. The
+token is stored and sent with subsequent requests so posts and comments can be
+created.
 
 # Getting Started with Create React App
 

--- a/src/App.js
+++ b/src/App.js
@@ -4,22 +4,37 @@ import Post from './components/Post';
 import CreatePost from './components/CreatePost';
 import SignUp from './components/SignUp';
 import Login from './components/Login';
+import { AuthProvider, useAuth } from './AuthContext';
 import './App.css';
+
+function Navigation() {
+  const { token, logout } = useAuth();
+  return (
+    <nav>
+      <Link to="/">Posts</Link> | <Link to="/signup">Sign Up</Link> |{' '}
+      {token ? (
+        <button onClick={logout}>Logout</button>
+      ) : (
+        <Link to="/login">Login</Link>
+      )}
+    </nav>
+  );
+}
 
 function App() {
   return (
-    <Router>
-      <nav>
-        <Link to="/">Posts</Link> | <Link to="/signup">Sign Up</Link> | <Link to="/login">Login</Link>
-      </nav>
-      <Routes>
-        <Route path="/" element={<Posts />} />
-        <Route path="/create" element={<CreatePost />} />
-        <Route path="/signup" element={<SignUp />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/posts/:id" element={<Post />} />
-      </Routes>
-    </Router>
+    <AuthProvider>
+      <Router>
+        <Navigation />
+        <Routes>
+          <Route path="/" element={<Posts />} />
+          <Route path="/create" element={<CreatePost />} />
+          <Route path="/signup" element={<SignUp />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/posts/:id" element={<Post />} />
+        </Routes>
+      </Router>
+    </AuthProvider>
   );
 }
 

--- a/src/AuthContext.js
+++ b/src/AuthContext.js
@@ -1,0 +1,27 @@
+import { createContext, useContext, useState } from 'react';
+
+export const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+
+  const login = (newToken) => {
+    setToken(newToken);
+    localStorage.setItem('token', newToken);
+  };
+
+  const logout = () => {
+    setToken(null);
+    localStorage.removeItem('token');
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,14 @@
+import { useAuth } from './AuthContext';
+
+const BASE = process.env.REACT_APP_API_URL || 'http://localhost:8080';
+
+export function useApi() {
+  const { token } = useAuth();
+  return async (path, options = {}) => {
+    const headers = { ...(options.headers || {}) };
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+    return fetch(`${BASE}${path}`, { ...options, headers });
+  };
+}

--- a/src/components/CreatePost.js
+++ b/src/components/CreatePost.js
@@ -1,13 +1,15 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useApi } from '../api';
 
 export default function CreatePost() {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const navigate = useNavigate();
+  const api = useApi();
   const submit = async (e) => {
     e.preventDefault();
-    await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:5000'}/posts`, {
+    await api('/posts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ title, content }),

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,21 +1,27 @@
 import { useState } from 'react';
+import { useAuth } from '../AuthContext';
+
+const API = process.env.REACT_APP_API_URL || 'http://localhost:8080';
 
 export default function Login() {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const [userId, setUserId] = useState('');
+  const { login } = useAuth();
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:5000'}/login`, {
+    const res = await fetch(`${API}/auth/token`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ userId }),
     });
+    if (res.ok) {
+      const data = await res.json();
+      login(data.token);
+    }
   };
   return (
     <form onSubmit={handleSubmit}>
       <h2>Login</h2>
-      <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
-      <input value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" type="password" />
+      <input value={userId} onChange={(e) => setUserId(e.target.value)} placeholder="User ID" />
       <button type="submit">Login</button>
     </form>
   );

--- a/src/components/Login.test.js
+++ b/src/components/Login.test.js
@@ -1,0 +1,33 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Login from './Login';
+import { AuthContext } from '../AuthContext';
+
+function renderWithContext(ui, { login = jest.fn() } = {}) {
+  return {
+    login,
+    ...render(
+      <AuthContext.Provider value={{ token: null, login }}>
+        {ui}
+      </AuthContext.Provider>
+    ),
+  };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('submits user id and stores token', async () => {
+  const { login } = renderWithContext(<Login />);
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ token: 'abc123' }),
+  });
+
+  userEvent.type(screen.getByPlaceholderText(/User ID/i), '42');
+  userEvent.click(screen.getByRole('button', { name: /Login/i }));
+
+  await waitFor(() => expect(fetch).toHaveBeenCalled());
+  await waitFor(() => expect(login).toHaveBeenCalledWith('abc123'));
+});

--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -1,19 +1,21 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { useApi } from '../api';
 
 export default function Post() {
   const { id } = useParams();
   const [post, setPost] = useState(null);
   const [comment, setComment] = useState('');
+  const api = useApi();
   useEffect(() => {
-    fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:5000'}/posts/${id}`)
+    api(`/posts/${id}`)
       .then(res => res.json())
       .then(setPost);
   }, [id]);
 
   const submitComment = async (e) => {
     e.preventDefault();
-    await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:5000'}/posts/${id}/comments`, {
+    await api(`/posts/${id}/comments`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text: comment }),

--- a/src/components/Posts.js
+++ b/src/components/Posts.js
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useApi } from '../api';
 
 export default function Posts() {
   const [posts, setPosts] = useState([]);
+  const api = useApi();
   useEffect(() => {
-    fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:5000'}/posts`)
+    api('/posts')
       .then(res => res.json())
       .then(setPosts);
   }, []);

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -1,21 +1,39 @@
 import { useState } from 'react';
+import { useAuth } from '../AuthContext';
+
+const API = process.env.REACT_APP_API_URL || 'http://localhost:8080';
 
 export default function SignUp() {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [gender, setGender] = useState('');
+  const [birthYear, setBirthYear] = useState('');
+  const { login } = useAuth();
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:5000'}/signup`, {
+    const res = await fetch(`${API}/users`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ name, gender, birthYear: parseInt(birthYear, 10) }),
     });
+    if (res.ok) {
+      const user = await res.json();
+      const tokenRes = await fetch(`${API}/auth/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: user.id }),
+      });
+      if (tokenRes.ok) {
+        const data = await tokenRes.json();
+        login(data.token);
+      }
+    }
   };
   return (
     <form onSubmit={handleSubmit}>
       <h2>Sign Up</h2>
-      <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
-      <input value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" type="password" />
+      <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" />
+      <input value={gender} onChange={(e) => setGender(e.target.value)} placeholder="Gender" />
+      <input value={birthYear} onChange={(e) => setBirthYear(e.target.value)} placeholder="Birth Year" />
       <button type="submit">Sign Up</button>
     </form>
   );

--- a/src/components/SignUp.test.js
+++ b/src/components/SignUp.test.js
@@ -1,0 +1,35 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SignUp from './SignUp';
+import { AuthContext } from '../AuthContext';
+
+function renderWithContext(ui, { login = jest.fn() } = {}) {
+  return {
+    login,
+    ...render(
+      <AuthContext.Provider value={{ token: null, login }}>
+        {ui}
+      </AuthContext.Provider>
+    ),
+  };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('creates user and requests token', async () => {
+  const { login } = renderWithContext(<SignUp />);
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 1 }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ token: 'jwt' }) });
+
+  userEvent.type(screen.getByPlaceholderText(/Name/i), 'Jane');
+  userEvent.type(screen.getByPlaceholderText(/Gender/i), 'F');
+  userEvent.type(screen.getByPlaceholderText(/Birth Year/i), '2000');
+  userEvent.click(screen.getByRole('button', { name: /Sign Up/i }));
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+  await waitFor(() => expect(login).toHaveBeenCalledWith('jwt'));
+});


### PR DESCRIPTION
## Summary
- export `AuthContext` constant
- add tests for `Login` and `SignUp` components

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_684ecea3e6d48320a0b0a04330fc945d