### PR TITLE
Enable gender select on signup

### DIFF
--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -32,7 +32,18 @@ export default function SignUp() {
     <form onSubmit={handleSubmit}>
       <h2>Sign Up</h2>
       <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" />
-      <input value={gender} onChange={(e) => setGender(e.target.value)} placeholder="Gender" />
+      <label>
+        Gender
+        <select
+          aria-label="Gender"
+          value={gender}
+          onChange={(e) => setGender(e.target.value)}
+        >
+          <option value="">Select Gender</option>
+          <option value="male">Male</option>
+          <option value="female">Female</option>
+        </select>
+      </label>
       <input value={birthYear} onChange={(e) => setBirthYear(e.target.value)} placeholder="Birth Year" />
       <button type="submit">Sign Up</button>
     </form>

--- a/src/components/SignUp.test.js
+++ b/src/components/SignUp.test.js
@@ -26,7 +26,7 @@ test('creates user and requests token', async () => {
     .mockResolvedValueOnce({ ok: true, json: async () => ({ token: 'jwt' }) });
 
   userEvent.type(screen.getByPlaceholderText(/Name/i), 'Jane');
-  userEvent.type(screen.getByPlaceholderText(/Gender/i), 'F');
+  userEvent.selectOptions(screen.getByLabelText(/Gender/i), 'female');
   userEvent.type(screen.getByPlaceholderText(/Birth Year/i), '2000');
   userEvent.click(screen.getByRole('button', { name: /Sign Up/i }));
 


### PR DESCRIPTION
## Summary
- update SignUp form to select male or female
- adjust unit test for SignUp component

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684ed3ca6ad88320b90b086eed927e87