### PR TITLE
Add error handling to auth forms

### DIFF
--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -5,17 +5,22 @@ const API = process.env.REACT_APP_API_URL || 'http://localhost:8080';
 
 export default function Login() {
   const [userId, setUserId] = useState('');
+  const [error, setError] = useState('');
   const { login } = useAuth();
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const res = await fetch(`${API}/auth/token`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ userId }),
-    });
-    if (res.ok) {
+    try {
+      const res = await fetch(`${API}/auth/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId }),
+      });
+      if (!res.ok) throw new Error('Failed to fetch token');
       const data = await res.json();
       login(data.token);
+      setError('');
+    } catch (err) {
+      setError('Login failed');
     }
   };
   return (
@@ -23,6 +28,7 @@ export default function Login() {
       <h2>Login</h2>
       <input value={userId} onChange={(e) => setUserId(e.target.value)} placeholder="User ID" />
       <button type="submit">Login</button>
+      {error && <p role="alert">{error}</p>}
     </form>
   );
 }

--- a/src/components/Login.test.js
+++ b/src/components/Login.test.js
@@ -31,3 +31,13 @@ test('submits user id and stores token', async () => {
   await waitFor(() => expect(fetch).toHaveBeenCalled());
   await waitFor(() => expect(login).toHaveBeenCalledWith('abc123'));
 });
+
+test('shows error message on failure', async () => {
+  renderWithContext(<Login />);
+  global.fetch = jest.fn().mockRejectedValueOnce(new Error('network'));
+
+  userEvent.type(screen.getByPlaceholderText(/User ID/i), '42');
+  userEvent.click(screen.getByRole('button', { name: /Login/i }));
+
+  await screen.findByRole('alert');
+});

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -7,25 +7,35 @@ export default function SignUp() {
   const [name, setName] = useState('');
   const [gender, setGender] = useState('');
   const [birthYear, setBirthYear] = useState('');
+  const [error, setError] = useState('');
   const { login } = useAuth();
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const res = await fetch(`${API}/users`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, gender, birthYear: parseInt(birthYear, 10) }),
-    });
-    if (res.ok) {
+    try {
+      const res = await fetch(`${API}/users`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          gender,
+          birthYear: parseInt(birthYear, 10),
+        }),
+      });
+      if (!res.ok) throw new Error('Failed to create user');
+
       const user = await res.json();
       const tokenRes = await fetch(`${API}/auth/token`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ userId: user.id }),
       });
-      if (tokenRes.ok) {
-        const data = await tokenRes.json();
-        login(data.token);
-      }
+      if (!tokenRes.ok) throw new Error('Failed to fetch token');
+
+      const data = await tokenRes.json();
+      login(data.token);
+      setError('');
+    } catch (err) {
+      setError('Sign up failed');
     }
   };
   return (
@@ -46,6 +56,7 @@ export default function SignUp() {
       </label>
       <input value={birthYear} onChange={(e) => setBirthYear(e.target.value)} placeholder="Birth Year" />
       <button type="submit">Sign Up</button>
+      {error && <p role="alert">{error}</p>}
     </form>
   );
 }

--- a/src/components/SignUp.test.js
+++ b/src/components/SignUp.test.js
@@ -33,3 +33,15 @@ test('creates user and requests token', async () => {
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
   await waitFor(() => expect(login).toHaveBeenCalledWith('jwt'));
 });
+
+test('shows error message on failure', async () => {
+  renderWithContext(<SignUp />);
+  global.fetch = jest.fn().mockRejectedValueOnce(new Error('network'));
+
+  userEvent.type(screen.getByPlaceholderText(/Name/i), 'Jane');
+  userEvent.selectOptions(screen.getByLabelText(/Gender/i), 'female');
+  userEvent.type(screen.getByPlaceholderText(/Birth Year/i), '2000');
+  userEvent.click(screen.getByRole('button', { name: /Sign Up/i }));
+
+  await screen.findByRole('alert');
+});


### PR DESCRIPTION
## Summary
- add try/catch around API requests in Login and SignUp
- show an error message on request failure
- test the new error handling logic

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684ed770d3dc8320a2759a61859798cb