### PR TITLE
Deduplicate API base URL constant

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,6 @@
 import { useAuth } from './AuthContext';
 
-const BASE = process.env.REACT_APP_API_URL || 'http://localhost:8080';
+export const API = process.env.REACT_APP_API_URL || 'http://localhost:8080';
 
 export function useApi() {
   const { token } = useAuth();
@@ -9,6 +9,6 @@ export function useApi() {
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
     }
-    return fetch(`${BASE}${path}`, { ...options, headers });
+    return fetch(`${API}${path}`, { ...options, headers });
   };
 }

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useAuth } from '../AuthContext';
-
-const API = process.env.REACT_APP_API_URL || 'http://localhost:8080';
+import { API } from '../api';
 
 export default function Login() {
   const [userId, setUserId] = useState('');

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useAuth } from '../AuthContext';
-
-const API = process.env.REACT_APP_API_URL || 'http://localhost:8080';
+import { API } from '../api';
 
 export default function SignUp() {
   const [name, setName] = useState('');


### PR DESCRIPTION
## Summary
- export API base URL from `src/api.js`
- use shared API constant in `SignUp.js` and `Login.js`

## Testing
- `CI=true npm test --silent --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_684edc9acb1883209f91d5070f6b8ef6