### PR TITLE
Improve useApi stability

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,14 +1,18 @@
+import { useCallback } from 'react';
 import { useAuth } from './AuthContext';
 
 export const API = process.env.REACT_APP_API_URL || 'http://localhost:8080';
 
 export function useApi() {
   const { token } = useAuth();
-  return async (path, options = {}) => {
-    const headers = { ...(options.headers || {}) };
-    if (token) {
-      headers['Authorization'] = `Bearer ${token}`;
-    }
-    return fetch(`${API}${path}`, { ...options, headers });
-  };
+  return useCallback(
+    async (path, options = {}) => {
+      const headers = { ...(options.headers || {}) };
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+      }
+      return fetch(`${API}${path}`, { ...options, headers });
+    },
+    [token]
+  );
 }

--- a/src/api.test.js
+++ b/src/api.test.js
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import { AuthContext } from './AuthContext';
+import { useApi } from './api';
+
+let captured;
+function TestComponent() {
+  captured = useApi();
+  return null;
+}
+
+function renderWithToken(token) {
+  return render(
+    <AuthContext.Provider value={{ token }}>
+      <TestComponent />
+    </AuthContext.Provider>
+  );
+}
+
+test('useApi returns stable function when token is unchanged', () => {
+  const { rerender } = renderWithToken('abc');
+  const first = captured;
+  rerender(
+    <AuthContext.Provider value={{ token: 'abc' }}>
+      <TestComponent />
+    </AuthContext.Provider>
+  );
+  expect(captured).toBe(first);
+});

--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -11,7 +11,7 @@ export default function Post() {
     api(`/posts/${id}`)
       .then(res => res.json())
       .then(setPost);
-  }, [id]);
+  }, [id, api]);
 
   const submitComment = async (e) => {
     e.preventDefault();

--- a/src/components/Posts.js
+++ b/src/components/Posts.js
@@ -9,7 +9,7 @@ export default function Posts() {
     api('/posts')
       .then(res => res.json())
       .then(setPosts);
-  }, []);
+  }, [api]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- memoize the API wrapper with `useCallback`
- depend on the API wrapper in component effects
- add tests verifying the API wrapper's stability

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684edecbd978832090322ed47d83afc2