### PR TITLE
Add tests for posts components

### DIFF
--- a/src/components/__tests__/CreatePost.test.js
+++ b/src/components/__tests__/CreatePost.test.js
@@ -1,0 +1,34 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import CreatePost from '../CreatePost';
+import { AuthContext } from '../../AuthContext';
+
+function renderWithRouter(ui) {
+  return render(
+    <AuthContext.Provider value={{ token: null }}>
+      <MemoryRouter initialEntries={["/create"]}>
+        <Routes>
+          <Route path="/create" element={ui} />
+          <Route path="/" element={<div>Home</div>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('submits new post and navigates home', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+  renderWithRouter(<CreatePost />);
+  userEvent.type(screen.getByPlaceholderText(/Title/i), 'Hello');
+  userEvent.type(screen.getByPlaceholderText(/Content/i), 'World');
+  userEvent.click(screen.getByRole('button', { name: /Submit/i }));
+
+  await waitFor(() => expect(fetch).toHaveBeenCalled());
+  await screen.findByText('Home');
+});

--- a/src/components/__tests__/Post.test.js
+++ b/src/components/__tests__/Post.test.js
@@ -1,0 +1,38 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Post from '../Post';
+import { AuthContext } from '../../AuthContext';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ id: '1' }),
+}));
+
+function renderWithContext(ui) {
+  return render(
+    <AuthContext.Provider value={{ token: null }}>{ui}</AuthContext.Provider>
+  );
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('loads post and submits comment', async () => {
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 1, title: 'Hello', content: 'Content', comments: [] }),
+    })
+    .mockResolvedValueOnce({ ok: true });
+
+  renderWithContext(<Post />);
+
+  expect(await screen.findByText('Hello')).toBeInTheDocument();
+  userEvent.type(screen.getByPlaceholderText(/Comment/i), 'Nice');
+  userEvent.click(screen.getByRole('button', { name: /Add Comment/i }));
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+  await waitFor(() => expect(screen.getByPlaceholderText(/Comment/i)).toHaveValue(''));
+});

--- a/src/components/__tests__/Posts.test.js
+++ b/src/components/__tests__/Posts.test.js
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import Posts from '../Posts';
+import { AuthContext } from '../../AuthContext';
+import { MemoryRouter } from 'react-router-dom';
+
+function renderWithProviders(ui) {
+  return render(
+    <AuthContext.Provider value={{ token: null }}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('renders posts from api', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => [{ id: 1, title: 'First Post' }],
+  });
+
+  renderWithProviders(<Posts />);
+
+  expect(await screen.findByRole('link', { name: 'First Post' })).toBeInTheDocument();
+  expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/posts'), expect.any(Object));
+});


### PR DESCRIPTION
## Summary
- add tests for Posts to ensure posts list is rendered
- add tests for CreatePost to verify navigation after posting
- add tests for Post to check comment submission

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ee2e51bc48320aa154a8be1302264