### PR TITLE
Update posts API usage

### DIFF
--- a/src/components/CreatePost.js
+++ b/src/components/CreatePost.js
@@ -3,8 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useApi } from '../api';
 
 export default function CreatePost() {
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
+  const [text, setText] = useState('');
   const navigate = useNavigate();
   const api = useApi();
   const submit = async (e) => {
@@ -12,15 +11,14 @@ export default function CreatePost() {
     await api('/posts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title, content }),
+      body: JSON.stringify({ text }),
     });
     navigate('/');
   };
   return (
     <form onSubmit={submit}>
       <h2>Write Post</h2>
-      <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title" />
-      <textarea value={content} onChange={(e) => setContent(e.target.value)} placeholder="Content" />
+      <textarea value={text} onChange={(e) => setText(e.target.value)} placeholder="Write something" />
       <button type="submit">Submit</button>
     </form>
   );

--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -27,8 +27,7 @@ export default function Post() {
 
   return (
     <div>
-      <h3>{post.title}</h3>
-      <p>{post.content}</p>
+      <p>{post.text}</p>
       <form onSubmit={submitComment}>
         <input value={comment} onChange={(e) => setComment(e.target.value)} placeholder="Comment" />
         <button type="submit">Add Comment</button>

--- a/src/components/Posts.js
+++ b/src/components/Posts.js
@@ -18,7 +18,7 @@ export default function Posts() {
       <ul>
         {posts.map(p => (
           <li key={p.id}>
-            <Link to={`/posts/${p.id}`}>{p.title}</Link>
+            <Link to={`/posts/${p.id}`}>{p.text}</Link>
           </li>
         ))}
       </ul>

--- a/src/components/__tests__/CreatePost.test.js
+++ b/src/components/__tests__/CreatePost.test.js
@@ -25,8 +25,7 @@ test('submits new post and navigates home', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true });
 
   renderWithRouter(<CreatePost />);
-  userEvent.type(screen.getByPlaceholderText(/Title/i), 'Hello');
-  userEvent.type(screen.getByPlaceholderText(/Content/i), 'World');
+  userEvent.type(screen.getByPlaceholderText(/Write something/i), 'Hello world');
   userEvent.click(screen.getByRole('button', { name: /Submit/i }));
 
   await waitFor(() => expect(fetch).toHaveBeenCalled());

--- a/src/components/__tests__/Post.test.js
+++ b/src/components/__tests__/Post.test.js
@@ -23,7 +23,7 @@ test('loads post and submits comment', async () => {
     .fn()
     .mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ id: 1, title: 'Hello', content: 'Content', comments: [] }),
+      json: async () => ({ id: 1, text: 'Hello', comments: [] }),
     })
     .mockResolvedValueOnce({ ok: true });
 

--- a/src/components/__tests__/Posts.test.js
+++ b/src/components/__tests__/Posts.test.js
@@ -18,7 +18,7 @@ afterEach(() => {
 test('renders posts from api', async () => {
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
-    json: async () => [{ id: 1, title: 'First Post' }],
+    json: async () => [{ id: 1, text: 'First Post' }],
   });
 
   renderWithProviders(<Posts />);


### PR DESCRIPTION
## Summary
- use `text` payload when creating posts
- display post text across pages
- update tests for new API field

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ef4dd0834832081e3a970d359838d