### PR TITLE
Update comment handling

### DIFF
--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -20,6 +20,10 @@ export default function Post() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text: comment }),
     });
+    const res = await api(`/posts/${id}`);
+    if (res.ok) {
+      setPost(await res.json());
+    }
     setComment('');
   };
 

--- a/src/components/__tests__/Post.test.js
+++ b/src/components/__tests__/Post.test.js
@@ -25,7 +25,11 @@ test('loads post and submits comment', async () => {
       ok: true,
       json: async () => ({ id: 1, text: 'Hello', comments: [] }),
     })
-    .mockResolvedValueOnce({ ok: true });
+    .mockResolvedValueOnce({ ok: true })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 1, text: 'Hello', comments: [{ id: 2, text: 'Nice' }] }),
+    });
 
   renderWithContext(<Post />);
 
@@ -33,6 +37,7 @@ test('loads post and submits comment', async () => {
   userEvent.type(screen.getByPlaceholderText(/Comment/i), 'Nice');
   userEvent.click(screen.getByRole('button', { name: /Add Comment/i }));
 
-  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3));
+  expect(await screen.findByText('Nice')).toBeInTheDocument();
   await waitFor(() => expect(screen.getByPlaceholderText(/Comment/i)).toHaveValue(''));
 });


### PR DESCRIPTION
## Summary
- refresh comments after posting
- test comment shows right away

## Testing
- `npm install --silent`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684efc434074832090bfe02e11da7457