### PR TITLE
Fix JSON parsing errors

### DIFF
--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -8,17 +8,38 @@ import {
   List,
   ListItem,
   ListItemText,
+  Alert,
 } from '@mui/material';
 
 export default function Post() {
   const { id } = useParams();
   const [post, setPost] = useState(null);
+  const [error, setError] = useState('');
   const [comment, setComment] = useState('');
   const api = useApi();
   useEffect(() => {
     api(`/posts/${id}`)
-      .then(res => res.json())
-      .then(setPost);
+      .then(async (res) => {
+        if (!res.ok) {
+          if (res.status === 401) {
+            throw new Error('Login required');
+          }
+          throw new Error('Failed to load post');
+        }
+        try {
+          return await res.json();
+        } catch {
+          return null;
+        }
+      })
+      .then((data) => {
+        setPost(data);
+        setError('');
+      })
+      .catch((err) => {
+        setPost(null);
+        setError(err.message);
+      });
   }, [id, api]);
 
   const submitComment = async (e) => {
@@ -61,6 +82,11 @@ export default function Post() {
           </ListItem>
         ))}
       </List>
+      {error && (
+        <Alert severity="error" role="alert" sx={{ mt: 2 }}>
+          {error}
+        </Alert>
+      )}
     </div>
   );
 }

--- a/src/components/Posts.js
+++ b/src/components/Posts.js
@@ -7,15 +7,36 @@ import {
   List,
   ListItem,
   ListItemText,
+  Alert,
 } from '@mui/material';
 
 export default function Posts() {
   const [posts, setPosts] = useState([]);
+  const [error, setError] = useState('');
   const api = useApi();
   useEffect(() => {
     api('/posts')
-      .then(res => res.json())
-      .then(setPosts);
+      .then(async (res) => {
+        if (!res.ok) {
+          if (res.status === 401) {
+            throw new Error('Login required');
+          }
+          throw new Error('Failed to fetch posts');
+        }
+        try {
+          return await res.json();
+        } catch {
+          return [];
+        }
+      })
+      .then((data) => {
+        setPosts(data);
+        setError('');
+      })
+      .catch((err) => {
+        setError(err.message);
+        setPosts([]);
+      });
   }, [api]);
 
   return (
@@ -40,6 +61,11 @@ export default function Posts() {
           </ListItem>
         ))}
       </List>
+      {error && (
+        <Alert severity="error" role="alert" sx={{ mt: 2 }}>
+          {error}
+        </Alert>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- handle fetch failures and invalid JSON when listing posts and viewing a post
- show error alerts if a request fails (e.g. when unauthenticated)

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_684f92e50c7883208329bb89bc0dca0c