### PR TITLE
Improve post list display

### DIFF
--- a/src/components/Posts.js
+++ b/src/components/Posts.js
@@ -53,13 +53,36 @@ export default function Posts() {
         Write Post
       </Button>
       <List>
-        {posts.map(p => (
-          <ListItem key={p.id} disablePadding>
-            <ListItemText>
-              <Button component={RouterLink} to={`/posts/${p.id}`}>{p.text}</Button>
-            </ListItemText>
-          </ListItem>
-        ))}
+        {posts.map((p) => {
+          const lines = (p.text || '').split(/\r?\n/);
+          const first = lines[0] || '';
+          const second = lines[1] || '';
+          const third = lines[2] || '';
+          const color = (p.gender || '').toLowerCase() === 'male' ? 'blue' : 'hotpink';
+          const viewCount = p.viewCount || p.views || 0;
+          const commentCount = p.comments ? p.comments.length : p.commentCount || 0;
+          return (
+            <ListItem key={p.id} disablePadding>
+              <ListItemText>
+                <Button
+                  component={RouterLink}
+                  to={`/posts/${p.id}`}
+                  sx={{ textTransform: 'none', textAlign: 'left', display: 'block', py: 1 }}
+                >
+                  <Typography component="div" sx={{ fontWeight: 'bold' }}>
+                    <span style={{ color }}>{'\u25CF'}</span> {first}
+                  </Typography>
+                  {second && <Typography component="div">{second}</Typography>}
+                  {third && <Typography component="div">{third}</Typography>}
+                  <Typography component="div" sx={{ mt: 1 }}>
+                    <span role="img" aria-label="views">👁</span> {viewCount}{' '}
+                    <span role="img" aria-label="comments">💬</span> {commentCount}
+                  </Typography>
+                </Button>
+              </ListItemText>
+            </ListItem>
+          );
+        })}
       </List>
       {error && (
         <Alert severity="error" role="alert" sx={{ mt: 2 }}>

--- a/src/components/__tests__/Posts.test.js
+++ b/src/components/__tests__/Posts.test.js
@@ -23,6 +23,6 @@ test('renders posts from api', async () => {
 
   renderWithProviders(<Posts />);
 
-  expect(await screen.findByRole('link', { name: 'First Post' })).toBeInTheDocument();
+  expect(await screen.findByRole('link', { name: /First Post/ })).toBeInTheDocument();
   expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/posts'), expect.any(Object));
 });


### PR DESCRIPTION
## Summary
- enhance `Posts` list layout showing first three lines
- add gender dot and counts for views and comments
- adjust test for new link text

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f986d34f08320afac1ce1c1d9b93d