### PR TITLE
Fix comment reply display

### DIFF
--- a/src/components/__tests__/Post.test.js
+++ b/src/components/__tests__/Post.test.js
@@ -49,10 +49,9 @@ test('replies to a comment with parentCommentId', async () => {
       ok: true,
       json: async () => ({ id: 1, text: 'Hello', comments: [{ id: 2, text: 'Nice' }] }),
     })
-    .mockResolvedValueOnce({ ok: true })
     .mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ id: 1, text: 'Hello', comments: [{ id: 2, text: 'Nice', comments: [{ id: 3, text: 'Thanks' }] }] }),
+      json: async () => ({ id: 3, text: 'Thanks', parentCommentId: 2 }),
     });
 
   renderWithContext(<Post />);
@@ -62,7 +61,8 @@ test('replies to a comment with parentCommentId', async () => {
   userEvent.type(screen.getByPlaceholderText(/Comment/i), 'Thanks');
   userEvent.click(screen.getByRole('button', { name: /Add Comment/i }));
 
-  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3));
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
   const body = JSON.parse(fetch.mock.calls[1][1].body);
   expect(body).toEqual({ text: 'Thanks', parentCommentId: 2 });
+  expect(await screen.findByText(/Thanks/)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- show reply input below the comment being replied to
- insert new replies into state immediately
- update tests for inline reply form

## Testing
- `CI=1 npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684fc014be6083209a405aa68f0f8e7e