### PR TITLE
Limit replies to 1 depth

### DIFF
--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -86,13 +86,15 @@ export default function Post() {
                     {time}
                   </Typography>
                 )}
-                <Button
-                  size="small"
-                  sx={{ minWidth: 'auto', mr: 1 }}
-                  onClick={() => startReply(c)}
-                >
-                  대댓글
-                </Button>
+                {depth === 0 && (
+                  <Button
+                    size="small"
+                    sx={{ minWidth: 'auto', mr: 1 }}
+                    onClick={() => startReply(c)}
+                  >
+                    대댓글
+                  </Button>
+                )}
                 <Button size="small" onClick={openCommentMenu} sx={{ minWidth: 'auto' }}>
                   {'\u22EE'}
                 </Button>
@@ -121,7 +123,7 @@ export default function Post() {
             </div>
           </form>
         )}
-        {(c.comments || c.replies || []).map((child) => renderComment(child, depth + 1))}
+        {depth < 1 && (c.comments || c.replies || []).map((child) => renderComment(child, depth + 1))}
       </div>
     );
   };

--- a/src/components/__tests__/Post.test.js
+++ b/src/components/__tests__/Post.test.js
@@ -66,3 +66,25 @@ test('replies to a comment with parentCommentId', async () => {
   expect(body).toEqual({ text: 'Thanks', parentCommentId: 2 });
   expect(await screen.findByText(/Thanks/)).toBeInTheDocument();
 });
+
+test('does not show reply button for a reply comment', async () => {
+  global.fetch = jest.fn().mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      id: 1,
+      text: 'Hello',
+      comments: [
+        { id: 2, text: 'Nice', comments: [{ id: 3, text: 'Thanks', comments: [{ id: 4, text: 'More' }] }] },
+      ],
+    }),
+  });
+
+  renderWithContext(<Post />);
+
+  expect(await screen.findByText(/Nice/)).toBeInTheDocument();
+  expect(await screen.findByText(/Thanks/)).toBeInTheDocument();
+  expect(screen.queryByText(/More/)).not.toBeInTheDocument();
+
+  const replyButtons = screen.getAllByRole('button', { name: '대댓글' });
+  expect(replyButtons).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary
- only allow replies for top-level comments
- hide nested reply button and ignore deeper replies
- test nested reply behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684fca22b7248320bf53c17074334150