### PR TITLE
Fix comment reply labels and menu

### DIFF
--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -92,7 +92,7 @@ export default function Post() {
                     sx={{ minWidth: 'auto', mr: 1 }}
                     onClick={() => startReply(c)}
                   >
-                    대댓글
+                    답글
                   </Button>
                 )}
                 <Button size="small" onClick={openCommentMenu} sx={{ minWidth: 'auto' }}>
@@ -261,7 +261,6 @@ export default function Post() {
         onClose={closeCommentMenu}
       >
         <MenuItem onClick={closeCommentMenu}>신고하기</MenuItem>
-        <MenuItem onClick={closeCommentMenu}>이 사용자의 글 보지않기</MenuItem>
       </Menu>
       {error && (
         <Alert severity="error" role="alert" sx={{ mt: 2 }}>

--- a/src/components/__tests__/Post.test.js
+++ b/src/components/__tests__/Post.test.js
@@ -57,7 +57,7 @@ test('replies to a comment with parentCommentId', async () => {
   renderWithContext(<Post />);
 
   expect(await screen.findByText(/Nice/)).toBeInTheDocument();
-  userEvent.click(screen.getByRole('button', { name: '대댓글' }));
+  userEvent.click(screen.getByRole('button', { name: '답글' }));
   userEvent.type(screen.getByPlaceholderText(/Comment/i), 'Thanks');
   userEvent.click(screen.getByRole('button', { name: /Add Comment/i }));
 
@@ -85,6 +85,6 @@ test('does not show reply button for a reply comment', async () => {
   expect(await screen.findByText(/Thanks/)).toBeInTheDocument();
   expect(screen.queryByText(/More/)).not.toBeInTheDocument();
 
-  const replyButtons = screen.getAllByRole('button', { name: '대댓글' });
+  const replyButtons = screen.getAllByRole('button', { name: '답글' });
   expect(replyButtons).toHaveLength(1);
 });


### PR DESCRIPTION
## Summary
- update reply button label to `답글`
- remove '이 사용자의 글 보지않기' from comment menu
- adjust tests for new label

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684fcf7f2b6483209cf847c7b31bcfa6