### PR TITLE
Add createdAt display for comments

### DIFF
--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -148,6 +148,7 @@ export default function Post() {
         const normalize = (comments = []) =>
           comments.map((c) => ({
             ...c,
+            createdAt: c.createdAt || c.created || c.created_at,
             comments: normalize(c.comments || c.replies || []),
             replies: c.replies || c.comments,
           }));
@@ -179,14 +180,19 @@ export default function Post() {
       }
     }
     if (newComment) {
+      const normalized = {
+        ...newComment,
+        createdAt:
+          newComment.createdAt || newComment.created || newComment.created_at,
+      };
       setPost((prev) => {
         if (!prev) return prev;
         const insert = (list) => {
-          if (!replyTo) return [...list, newComment];
+          if (!replyTo) return [...list, normalized];
           return list.map((c) => {
             const children = c.comments || c.replies || [];
             if (c.id === replyTo.id) {
-              const updated = [...children, newComment];
+              const updated = [...children, normalized];
               return { ...c, comments: updated, replies: updated };
             }
             const updatedChildren = insert(children);

--- a/src/components/__tests__/Post.test.js
+++ b/src/components/__tests__/Post.test.js
@@ -88,3 +88,32 @@ test('does not show reply button for a reply comment', async () => {
   const replyButtons = screen.getAllByRole('button', { name: '대댓글' });
   expect(replyButtons).toHaveLength(1);
 });
+
+test('shows relative time for comments and replies', async () => {
+  const now = new Date('2025-06-16T12:00:00Z').getTime();
+  jest.spyOn(Date, 'now').mockReturnValue(now);
+  global.fetch = jest.fn().mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      id: 1,
+      text: 'Hello',
+      comments: [
+        {
+          id: 2,
+          text: 'Nice',
+          createdAt: '2025-06-16T11:59:00Z',
+          comments: [
+            { id: 3, text: 'Thanks', createdAt: '2025-06-16T11:50:00Z' },
+          ],
+        },
+      ],
+    }),
+  });
+
+  renderWithContext(<Post />);
+
+  expect(await screen.findByText('1분 전')).toBeInTheDocument();
+  expect(await screen.findByText('10분 전')).toBeInTheDocument();
+
+  Date.now.mockRestore();
+});


### PR DESCRIPTION
## Summary
- normalize comment timestamps on fetch and creation
- test relative time display for comments and replies

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ffd1cc64c83209b5460e871f26c6a