### PR TITLE
Add gray background for reply comments

### DIFF
--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -72,7 +72,14 @@ export default function Post() {
     const time = timeAgo(c.createdAt || c.created || c.created_at);
     return (
       <div key={c.id}>
-        <ListItem disablePadding alignItems="flex-start" sx={{ pl: depth * 2 }}>
+        <ListItem
+          disablePadding
+          alignItems="flex-start"
+          sx={{
+            pl: depth * 2,
+            backgroundColor: depth > 0 ? 'rgba(0,0,0,0.04)' : 'transparent',
+          }}
+        >
           <ListItemText
             primary={
               <Typography component="span">


### PR DESCRIPTION
## Summary
- make reply comments stand out with a light gray background

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850505dbe5083208d84c284b7d0fb25